### PR TITLE
Add minimal Electron front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,24 @@ Suivez les instructions pour effectuer les opérations vidéo souhaitées.
 ## Avertissement
 
 Ce script est destiné à un usage personnel et non commercial. Veuillez respecter les droits d'auteur et les conditions d'utilisation lors du téléchargement et de l'utilisation de vidéos depuis Internet.
+
+## Application Electron
+
+Une version expérimentale de VideoMaster est disponible dans le dossier `electron-app`. Cette application utilise Electron pour fournir une interface graphique simple.
+
+### Prérequis
+- Node.js
+- FFmpeg et yt-dlp disponibles dans le PATH
+
+### Lancer l'application
+```bash
+cd electron-app
+npm install
+npm start
+```
+
+Cela ouvrira une fenêtre permettant d'exécuter quelques fonctionnalités de base :
+- Téléchargement de vidéo ou d'audio
+- Conversion d'une vidéo en MP3
+- Découpage d'une vidéo
+

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VideoMaster</title>
+</head>
+<body>
+  <h1>VideoMaster</h1>
+  <label>Operation:
+    <select id="operation">
+      <option value="download-video">Download Video</option>
+      <option value="download-audio">Download Audio</option>
+      <option value="convert-mp3">Convert to MP3</option>
+      <option value="cut-video">Cut Video</option>
+    </select>
+  </label>
+  <div>
+    <label>URL:<input id="url" type="text"></label>
+  </div>
+  <div>
+    <label>Input File:<input id="input" type="text"></label>
+  </div>
+  <div>
+    <label>Output:<input id="output" type="text"></label>
+  </div>
+  <div>
+    <label>Start:<input id="start" type="text"></label>
+    <label>End:<input id="end" type="text"></label>
+  </div>
+  <button id="run">Run</button>
+  <pre id="log"></pre>
+
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "videomaster-electron",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^26.2.1"
+  }
+}

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -1,0 +1,34 @@
+const { exec } = require('child_process');
+
+document.getElementById('run').addEventListener('click', () => {
+  const op = document.getElementById('operation').value;
+  const url = document.getElementById('url').value;
+  const input = document.getElementById('input').value;
+  const output = document.getElementById('output').value;
+  const start = document.getElementById('start').value;
+  const end = document.getElementById('end').value;
+  let cmd = '';
+
+  switch(op) {
+    case 'download-video':
+      cmd = `yt-dlp -f bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best "${url}"`;
+      break;
+    case 'download-audio':
+      cmd = `yt-dlp -x --audio-format mp3 "${url}"`;
+      break;
+    case 'convert-mp3':
+      cmd = `ffmpeg -i "${input}" -vn -acodec mp3 "${output}.mp3"`;
+      break;
+    case 'cut-video':
+      cmd = `ffmpeg -i "${input}" -ss ${start} -to ${end} -c copy "${output}"`;
+      break;
+  }
+
+  const log = document.getElementById('log');
+  log.textContent = `Running: ${cmd}\n`;
+
+  const child = exec(cmd);
+  child.stdout.on('data', data => log.textContent += data);
+  child.stderr.on('data', data => log.textContent += data);
+  child.on('exit', code => log.textContent += `\nProcess exited with code ${code}`);
+});


### PR DESCRIPTION
## Summary
- document the new Electron app in README
- scaffold a small Electron application in `electron-app`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f53159558832ba5518f5646e2753b