### PR TITLE
Improve Electron UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,24 @@ Suivez les instructions pour effectuer les opérations vidéo souhaitées.
 ## Avertissement
 
 Ce script est destiné à un usage personnel et non commercial. Veuillez respecter les droits d'auteur et les conditions d'utilisation lors du téléchargement et de l'utilisation de vidéos depuis Internet.
+
+## Application Electron
+
+Une version expérimentale de VideoMaster est disponible dans le dossier `electron-app`. Cette application utilise Electron pour fournir une interface graphique simple.
+
+### Prérequis
+- Node.js
+- FFmpeg et yt-dlp disponibles dans le PATH
+
+### Lancer l'application
+```bash
+cd electron-app
+npm install
+npm start
+```
+
+Cela ouvrira une interface avec deux onglets :
+- **Download** pour récupérer des vidéos ou uniquement l'audio.
+- **Tools** pour quelques commandes FFmpeg : conversion en MP3, découpage, compression ou extraction d'audio.
+
+Les commandes sélectionnées s'exécutent directement depuis l'application.

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VideoMaster</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>VideoMaster</h1>
+  <ul class="tabs">
+    <li data-tab="download" class="active">Download</li>
+    <li data-tab="tools">Tools</li>
+  </ul>
+  <div id="download" class="tab">
+    <label>URL:<input id="url" type="text"></label>
+    <label>Download type:
+      <select id="download-op">
+        <option value="download-video">Video</option>
+        <option value="download-audio">Audio</option>
+      </select>
+    </label>
+  </div>
+  <div id="tools" class="tab hidden">
+    <label>Input:<input id="input" type="text"></label>
+    <label>Output:<input id="output" type="text"></label>
+    <label>Tool:
+      <select id="tool-op">
+        <option value="convert-mp3">Convert to MP3</option>
+        <option value="cut-video">Cut Video</option>
+        <option value="compress">Compress</option>
+        <option value="extract-audio">Extract Audio</option>
+      </select>
+    </label>
+    <div id="time-range" class="hidden">
+      <label>Start:<input id="start" type="text"></label>
+      <label>End:<input id="end" type="text"></label>
+    </div>
+  </div>
+  <button id="run">Run</button>
+  <pre id="log"></pre>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "videomaster-electron",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^26.2.1"
+  }
+}

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -1,0 +1,74 @@
+const { exec } = require('child_process');
+
+const tabs = document.querySelectorAll('.tabs li');
+const tabViews = document.querySelectorAll('.tab');
+
+// switch tabs
+tabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelector('.tabs li.active').classList.remove('active');
+    tab.classList.add('active');
+    tabViews.forEach(view => view.classList.add('hidden'));
+    document.getElementById(tab.dataset.tab).classList.remove('hidden');
+  });
+});
+
+const toolOp = document.getElementById('tool-op');
+const timeRange = document.getElementById('time-range');
+function toggleTimeRange() {
+  if (toolOp.value === 'cut-video') {
+    timeRange.classList.remove('hidden');
+  } else {
+    timeRange.classList.add('hidden');
+  }
+}
+toolOp.addEventListener('change', toggleTimeRange);
+toggleTimeRange();
+
+function runCommand(cmd) {
+  const log = document.getElementById('log');
+  log.textContent = `Running: ${cmd}\n`;
+  const child = exec(cmd);
+  child.stdout.on('data', data => log.textContent += data);
+  child.stderr.on('data', data => log.textContent += data);
+  child.on('exit', code => log.textContent += `\nExited with code ${code}`);
+}
+
+document.getElementById('run').addEventListener('click', () => {
+  const activeTab = document.querySelector('.tabs li.active').dataset.tab;
+  let cmd = '';
+
+  if (activeTab === 'download') {
+    const url = document.getElementById('url').value;
+    const op = document.getElementById('download-op').value;
+    if (op === 'download-video') {
+      cmd = `yt-dlp -f bestvideo+bestaudio "${url}"`;
+    } else {
+      cmd = `yt-dlp -x --audio-format mp3 "${url}"`;
+    }
+  } else if (activeTab === 'tools') {
+    const input = document.getElementById('input').value;
+    const output = document.getElementById('output').value;
+    const op = toolOp.value;
+    switch (op) {
+      case 'convert-mp3':
+        cmd = `ffmpeg -i "${input}" -vn -acodec mp3 "${output}.mp3"`;
+        break;
+      case 'cut-video':
+        const start = document.getElementById('start').value;
+        const end = document.getElementById('end').value;
+        cmd = `ffmpeg -i "${input}" -ss ${start} -to ${end} -c copy "${output}"`;
+        break;
+      case 'compress':
+        cmd = `ffmpeg -i "${input}" -vcodec libx264 -crf 28 "${output}"`;
+        break;
+      case 'extract-audio':
+        cmd = `ffmpeg -i "${input}" -q:a 0 -map a "${output}.mp3"`;
+        break;
+    }
+  }
+
+  if (cmd) {
+    runCommand(cmd);
+  }
+});

--- a/electron-app/style.css
+++ b/electron-app/style.css
@@ -1,0 +1,14 @@
+body { font-family: sans-serif; margin: 0; padding: 0 1rem; }
+.tabs { list-style: none; padding: 0; display: flex; border-bottom: 1px solid #ccc; }
+.tabs li { padding: .5rem 1rem; cursor: pointer; }
+.tabs li.active { border-bottom: 2px solid #0078d7; font-weight: bold; }
+.tab { margin-top: 1rem; }
+.hidden { display: none; }
+label { display: block; margin-bottom: .5rem; }
+input, select { width: 100%; max-width: 400px; }
+button { margin-top: 1rem; }
+pre { background: #f5f5f5; padding: 1rem; margin-top: 1rem; overflow: auto; }
+@media (min-width: 600px) {
+  .tab { display: flex; flex-wrap: wrap; }
+  label { width: 45%; margin-right: 5%; }
+}


### PR DESCRIPTION
## Summary
- redesign Electron app with basic tabs and responsive layout
- add CSS styles and more options to the renderer
- document the new UI in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f53159558832ba5518f5646e2753b